### PR TITLE
Added support for ERC20 token with less than 18 decimals

### DIFF
--- a/contracts/IVaultHandler.sol
+++ b/contracts/IVaultHandler.sol
@@ -14,7 +14,6 @@ import "@openzeppelin/contracts/introspection/IERC165.sol";
 import "./TCAP.sol";
 import "./Orchestrator.sol";
 import "./oracles/ChainlinkOracle.sol";
-import "hardhat/console.sol";
 
 interface IRewardHandler {
   function stake(address _staker, uint256 amount) external;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"@typechain/ethers-v5": "^5.0.0",
 		"@types/chai": "^4.2.11",
 		"hardhat-tracer": "^1.0.0-alpha.6",
-		"solc": "0.7.5"
+		"solc": "0.7.5",
+		"@defi-wonderland/smock": "^2.0.7"
 	},
 	"devDependencies": {
 		"@nomiclabs/hardhat-ethers": "^2.0.1",

--- a/test/ERCNon18DecimalsVaultHandler.test.ts
+++ b/test/ERCNon18DecimalsVaultHandler.test.ts
@@ -1,0 +1,659 @@
+import { expect } from "chai";
+import { BigNumber, Contract, constants, utils, Signer } from "ethers";
+import hre, { waffle } from "hardhat";
+import { deployContract } from "./utils";
+import { MockContract, smock } from '@defi-wonderland/smock';
+
+// ************************************************************************************************
+// NOTE
+// 1.The tests in this file use two vaults, one with 18 decimals and another with less than 18.
+// 2.Calculation for tokens with 18 decimals are assumed to be correct.
+// 3.Different vault parameters are then compared for an equal amount of collateral deposited in USD
+// 4.By checking that the calculations for both tokens are equivalent in USD, from `3` we can
+//   conclude that the calculations for tokens with less than 18 decimals are correct.
+// ************************************************************************************************
+
+
+export async function fakeDeployContract(name: string, deployer: Signer, args: any[]) {
+	const contractCls = await smock.mock(name);
+	return await contractCls.connect(deployer).deploy(...args);
+}
+
+
+describe("ERC20 Vaults With Non 18 Decimal", async function () {
+	let CTX: Contract;
+	let orchestrator: Contract;
+	let treasury: Contract;
+	let tCAP: Contract;
+	let aggregatorInterfaceTCAP: MockContract<Contract>;
+	let tCAPOracle: Contract;
+	let wBTC: Contract;
+	let aggregatorInterfaceWBTC: MockContract<Contract>;
+	let wBTCOracle: Contract;
+	let DAI: Contract;
+	let aggregatorInterfaceDAI: MockContract<Contract>;
+	let DAIOracle: Contract;
+	let aggregatorInterfaceWETH: MockContract<Contract>;
+	let ETHOracle: Contract;
+	let wBTCVaultHandler: Contract;
+	let rewardHandlerWBTC: Contract;
+	let DAIVaultHandler: Contract;
+	let rewardHandlerDAI: Contract;
+	let tcapOracleValue: BigNumber;
+	let wBTCOracleValue: BigNumber;
+	let DAIOracleValue: BigNumber;
+	const [wallet, acc1, acc2, acc3, acc4] = waffle.provider.getWallets();
+
+	beforeEach(async () => {
+		const { timestamp: now } = await waffle.provider.getBlock("latest");
+		CTX = await deployContract("Ctx", wallet, [wallet.address, wallet.address, now + 60 * 60]);
+		orchestrator = await deployContract("Orchestrator", wallet, [wallet.address]);
+		treasury = await deployContract("ITreasury", wallet, [wallet.address]);
+		tCAP = await deployContract(
+			"TCAP", wallet, ["TCAP Token", "TCAP", 0, orchestrator.address]
+		);
+		aggregatorInterfaceTCAP = await fakeDeployContract("AggregatorInterface", wallet, []);
+		tCAPOracle = await deployContract(
+			"ChainlinkOracle",
+			wallet,
+			[aggregatorInterfaceTCAP.address, wallet.address]
+		);
+		wBTC = await deployContract("WBTC", wallet, []);
+		aggregatorInterfaceWBTC = await fakeDeployContract("AggregatorInterface", wallet, []);
+		wBTCOracle = await deployContract(
+			"ChainlinkOracle",
+			wallet,
+			[aggregatorInterfaceWBTC.address, wallet.address]
+		);
+		DAI = await deployContract("DAI", wallet, []);
+		aggregatorInterfaceDAI = await fakeDeployContract("AggregatorInterface", wallet, []);
+		DAIOracle = await deployContract(
+			"ChainlinkOracle",
+			wallet,
+			[aggregatorInterfaceDAI.address, wallet.address]
+		);
+		aggregatorInterfaceWETH = await fakeDeployContract("AggregatorInterface", wallet, []);
+		ETHOracle = await deployContract(
+			"ChainlinkOracle",
+			wallet,
+			[aggregatorInterfaceWETH.address, wallet.address]
+		);
+		let nonce = await wallet.getTransactionCount();
+		let RewardHandlerAddress = hre.ethers.utils.getContractAddress({
+				from: wallet.address,
+				nonce: nonce + 1,
+		});
+		wBTCVaultHandler = await deployContract(
+			"ERC20VaultHandler",
+			wallet,
+			[
+				orchestrator.address,
+				"10000000000",
+				"150",
+				"1",
+				"10",
+				tCAPOracle.address,
+				tCAP.address,
+				wBTC.address,
+				wBTCOracle.address,
+				ETHOracle.address,
+				RewardHandlerAddress,
+				treasury.address,
+			]
+		);
+		rewardHandlerWBTC = await deployContract(
+			"RewardHandler",
+			wallet,
+			[orchestrator.address, CTX.address, wBTCVaultHandler.address]
+		);
+
+		nonce = await wallet.getTransactionCount();
+		RewardHandlerAddress = hre.ethers.utils.getContractAddress({
+				from: wallet.address,
+				nonce: nonce + 1,
+		});
+		DAIVaultHandler = await deployContract(
+			"ERC20VaultHandler",
+			wallet,
+			[
+				orchestrator.address,
+				"10000000000",
+				"150",
+				"1",
+				"10",
+				tCAPOracle.address,
+				tCAP.address,
+				DAI.address,
+				DAIOracle.address,
+				ETHOracle.address,
+				RewardHandlerAddress,
+				treasury.address,
+			]
+		);
+		rewardHandlerDAI = await deployContract(
+			"RewardHandler",
+			wallet,
+			[orchestrator.address, CTX.address, DAIVaultHandler.address]
+		);
+		// add Vaults
+		await orchestrator.addTCAPVault(tCAP.address, wBTCVaultHandler.address);
+		await orchestrator.addTCAPVault(tCAP.address, DAIVaultHandler.address);
+
+		// Mint tokens
+		// 10000 * 10 ** 8
+		await wBTC.mint(wallet.address, "1000000000000");
+		// 10000 * 10 ** 18
+		await DAI.mint(wallet.address, "10000000000000000000000");
+
+		// Mock Price of Tcap
+		tcapOracleValue = BigNumber.from("214270586778100000000");
+		aggregatorInterfaceTCAP.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			tcapOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await tCAPOracle.getLatestAnswer()).to.be.eq(tcapOracleValue);
+
+		// Mock Price of wBTC
+		wBTCOracleValue = BigNumber.from("4271800000000");
+		aggregatorInterfaceWBTC.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			wBTCOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await wBTCOracle.getLatestAnswer()).to.be.eq(wBTCOracleValue);
+
+		// Mock Price of DAI
+		DAIOracleValue = BigNumber.from("100103401");
+		aggregatorInterfaceDAI.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			DAIOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await DAIOracle.getLatestAnswer()).to.be.eq(DAIOracleValue);
+
+	});
+
+	it("...check collateralDecimalsAdjustmentFactor", async () => {
+		// wBTC has 8 decimals
+		// collateralDecimalsAdjustmentFactor = 10 ** (18 -8) = 10 ** 10
+		expect(
+			await wBTCVaultHandler.collateralDecimalsAdjustmentFactor()
+		).to.be.eq(BigNumber.from(`${10 ** 10}`));
+		// DAI has 18 decimals
+		// collateralDecimalsAdjustmentFactor = 10 ** (18 - 18) = 1
+		expect(
+			await DAIVaultHandler.collateralDecimalsAdjustmentFactor()
+		).to.be.eq(BigNumber.from("1"));
+	});
+
+	it("...should have same amount of collateral in USD", async () => {
+		let tcapAmount = BigNumber.from(`${2 * 10 ** 18}`)
+		const wBTCCollateralRequired = await wBTCVaultHandler.requiredCollateral(tcapAmount);
+		const DAICollateralRequired = await DAIVaultHandler.requiredCollateral(tcapAmount);
+		let wBTCtoUSD = wBTCCollateralRequired.mul(wBTCOracleValue).div(BigNumber.from(`${10 ** (8 + 8)}`));
+		// 8 decimal places for DAI and 18 decimal places for oracle
+		let DAItoUSD = DAICollateralRequired.mul(DAIOracleValue).div(
+				BigNumber.from(`${10 ** 18}`)).div(BigNumber.from(`${10 ** 8}`)
+		);
+
+		// Check that the required Collateral for DAI and WBTC are equivalent in USD
+		expect(wBTCtoUSD).to.be.eq(DAItoUSD);
+
+	});
+
+	it("...should have same Vault Ratio", async () => {
+		const USDAmountCollateralToDeposit = BigNumber.from(1000);
+		// equivalent in decimals places supported by WBTC
+		const btcCollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			10 ** 8 // wBTC supports 8 decimals
+		).div(
+			wBTCOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		const DAICollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			`${10 ** 18}` // DAI supports 18 decimals
+		).div(
+			DAIOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		// TCAP amount to be minted by both vaults
+		// A weird number is chosen in order to check the precision of the math.
+		let tcapAmount = BigNumber.from("2418604651162790553");
+
+		await wBTCVaultHandler.createVault();
+		await wBTC.approve(wBTCVaultHandler.address, btcCollateralAmountDeposit);
+		await wBTCVaultHandler.addCollateral(btcCollateralAmountDeposit);
+		// Mint a small amount of TCAP
+		await wBTCVaultHandler.mint(tcapAmount);
+		const btcVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(btcVaultRatio).to.be.above(150);
+
+		await DAI.approve(DAIVaultHandler.address, DAICollateralAmountDeposit);
+		await DAIVaultHandler.createVault();
+		await DAIVaultHandler.addCollateral(DAICollateralAmountDeposit);
+		// Mint same amount of Tcap minted in Btc Vault
+		await DAIVaultHandler.mint(tcapAmount);
+		const daiVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(daiVaultRatio).to.be.above(150);
+
+		// Check that the vault ratio is the same since deposited amount in USD is same and
+		// The amount of TCAP minted is also the same.
+		// For TCAP = 2418604651162790553, btcVaultRatio is 192 and daiVaultRatio is 193
+		// The difference arises because of the integer precision of the EVM.
+		// A difference of 1 is acceptable in this case.
+		expect(btcVaultRatio.toNumber()).to.be.closeTo(daiVaultRatio.toNumber(), 1);
+	});
+
+	it("...should have same vault ratio after burning TCAP", async () => {
+		const USDAmountCollateralToDeposit = BigNumber.from(1000);
+		// equivalent in decimals places supported by WBTC
+		const btcCollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			10 ** 8 // wBTC supports 8 decimals
+		).div(
+			wBTCOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		const DAICollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			`${10 ** 18}` // DAI supports 18 decimals
+		).div(
+			DAIOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		// TCAP amount to be minted by both vaults
+		// A weird number is chosen in order to check the precision of the math.
+		// approx 2.4 TCAP
+		let tcapAmount = BigNumber.from("2418604651162790553");
+
+		await wBTCVaultHandler.createVault();
+		await wBTC.approve(wBTCVaultHandler.address, btcCollateralAmountDeposit);
+		await wBTCVaultHandler.addCollateral(btcCollateralAmountDeposit);
+		// Mint a small amount of TCAP
+		await wBTCVaultHandler.mint(tcapAmount);
+		const oldBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(oldBTCVaultRatio).to.be.above(150);
+
+		await DAI.approve(DAIVaultHandler.address, DAICollateralAmountDeposit);
+		await DAIVaultHandler.createVault();
+		await DAIVaultHandler.addCollateral(DAICollateralAmountDeposit);
+		// Mint same amount of Tcap minted in Btc Vault
+		await DAIVaultHandler.mint(tcapAmount);
+		const oldDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(oldDAIVaultRatio).to.be.above(150);
+		expect(oldBTCVaultRatio.toNumber()).to.be.closeTo(oldDAIVaultRatio.toNumber(), 1);
+
+		// approx 0.4 TCAP
+		const tcapToBurn = BigNumber.from("400000000000000000");
+		const burnFee = await wBTCVaultHandler.getFee(tcapToBurn);
+		// Make sure burn fee is same for both vaults
+		expect(burnFee).to.be.eq(await wBTCVaultHandler.getFee(tcapToBurn));
+
+		await wBTCVaultHandler.burn(tcapToBurn, {value: burnFee});
+		const newBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(newBTCVaultRatio).to.be.above(oldBTCVaultRatio);
+
+		await DAIVaultHandler.burn(tcapToBurn, {value: burnFee});
+		const newDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(newDAIVaultRatio).to.be.above(oldDAIVaultRatio);
+
+		expect(newBTCVaultRatio.toNumber()).to.be.closeTo(newDAIVaultRatio.toNumber(), 1);
+
+	});
+
+	it("...should have same vault ratio after removing collateral", async () => {
+		const USDAmountCollateralToDeposit = BigNumber.from(1000);
+		// equivalent in decimals places supported by WBTC
+		const btcCollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			10 ** 8 // wBTC supports 8 decimals
+		).div(
+			wBTCOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		const DAICollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			`${10 ** 18}` // DAI supports 18 decimals
+		).div(
+			DAIOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		// TCAP amount to be minted by both vaults
+		// A weird number is chosen in order to check the precision of the math.
+		// approx 2.4 TCAP
+		let tcapAmount = BigNumber.from("2418604651162790553");
+
+		await wBTCVaultHandler.createVault();
+		await wBTC.approve(wBTCVaultHandler.address, btcCollateralAmountDeposit);
+		await wBTCVaultHandler.addCollateral(btcCollateralAmountDeposit);
+		// Mint a small amount of TCAP
+		await wBTCVaultHandler.mint(tcapAmount);
+		const oldBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(oldBTCVaultRatio).to.be.above(150);
+
+		await DAI.approve(DAIVaultHandler.address, DAICollateralAmountDeposit);
+		await DAIVaultHandler.createVault();
+		await DAIVaultHandler.addCollateral(DAICollateralAmountDeposit);
+		// Mint same amount of Tcap minted in Btc Vault
+		await DAIVaultHandler.mint(tcapAmount);
+		const oldDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(oldDAIVaultRatio).to.be.above(150);
+		expect(oldBTCVaultRatio.toNumber()).to.be.closeTo(oldDAIVaultRatio.toNumber(), 1);
+
+		// 53 USD
+		const usdAmountToWithdraw = BigNumber.from(53);
+		const btcCollateralAmountWithdraw = usdAmountToWithdraw.mul(
+			10 ** 8 // wBTC supports 8 decimals
+		).div(
+			wBTCOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		const DAICollateralAmountWithdraw = usdAmountToWithdraw.mul(
+			`${10 ** 18}` // DAI supports 18 decimals
+		).div(
+			DAIOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+
+		await wBTCVaultHandler.removeCollateral(btcCollateralAmountWithdraw);
+		const newBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(newBTCVaultRatio).to.be.below(oldBTCVaultRatio);
+
+		await DAIVaultHandler.removeCollateral(DAICollateralAmountWithdraw);
+		const newDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(newDAIVaultRatio).to.be.below(oldDAIVaultRatio);
+
+		expect(newBTCVaultRatio.toNumber()).to.be.closeTo(newDAIVaultRatio.toNumber(), 1);
+	});
+
+	it("...should have same vault ratio when vault ratio goes down", async () => {
+		const USDAmountCollateralToDeposit = BigNumber.from(1000);
+		// equivalent in decimals places supported by WBTC
+		const btcCollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			10 ** 8 // wBTC supports 8 decimals
+		).div(
+			wBTCOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		const DAICollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			`${10 ** 18}` // DAI supports 18 decimals
+		).div(
+			DAIOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		// TCAP amount to be minted by both vaults
+		// A weird number is chosen in order to check the precision of the math.
+		// approx 2.4 TCAP
+		let tcapAmount = BigNumber.from("2418604651162790553");
+
+		await wBTCVaultHandler.createVault();
+		await wBTC.approve(wBTCVaultHandler.address, btcCollateralAmountDeposit);
+		await wBTCVaultHandler.addCollateral(btcCollateralAmountDeposit);
+		// Mint a small amount of TCAP
+		await wBTCVaultHandler.mint(tcapAmount);
+		const oldBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(oldBTCVaultRatio).to.be.above(150);
+
+		await DAI.approve(DAIVaultHandler.address, DAICollateralAmountDeposit);
+		await DAIVaultHandler.createVault();
+		await DAIVaultHandler.addCollateral(DAICollateralAmountDeposit);
+		// Mint same amount of Tcap minted in Btc Vault
+		await DAIVaultHandler.mint(tcapAmount);
+		const oldDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(oldDAIVaultRatio).to.be.above(150);
+		expect(oldBTCVaultRatio.toNumber()).to.be.closeTo(oldDAIVaultRatio.toNumber(), 1);
+
+		// Simulate Oracle price change
+		// reduce price by 30%, mul(70).div(100) -> 70%
+		const newWBTCOracleValue = wBTCOracleValue.mul(70).div(100);
+		aggregatorInterfaceWBTC.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			newWBTCOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await wBTCOracle.getLatestAnswer()).to.be.eq(newWBTCOracleValue);
+
+		const newDAIOracleValue = DAIOracleValue.mul(70).div(100);
+		aggregatorInterfaceDAI.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			newDAIOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await DAIOracle.getLatestAnswer()).to.be.eq(newDAIOracleValue);
+		const newBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(newBTCVaultRatio).to.be.below(150);
+		const newDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(newDAIVaultRatio).to.be.below(150);
+
+		expect(newBTCVaultRatio.toNumber()).to.be.closeTo(newDAIVaultRatio.toNumber(), 1);
+	});
+
+	it("...should have same requiredLiquidationTCAP when vault ratio goes down", async () => {
+		const USDAmountCollateralToDeposit = BigNumber.from(1000);
+		// equivalent in decimals places supported by WBTC
+		const btcCollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			10 ** 8 // wBTC supports 8 decimals
+		).div(
+			wBTCOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		const DAICollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			`${10 ** 18}` // DAI supports 18 decimals
+		).div(
+			DAIOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		// TCAP amount to be minted by both vaults
+		// A weird number is chosen in order to check the precision of the math.
+		// approx 2.4 TCAP
+		let tcapAmount = BigNumber.from("2418604651162790553");
+
+		await wBTCVaultHandler.createVault();
+		await wBTC.approve(wBTCVaultHandler.address, btcCollateralAmountDeposit);
+		await wBTCVaultHandler.addCollateral(btcCollateralAmountDeposit);
+		// Mint a small amount of TCAP
+		await wBTCVaultHandler.mint(tcapAmount);
+		const oldBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(oldBTCVaultRatio).to.be.above(150);
+
+		await DAI.approve(DAIVaultHandler.address, DAICollateralAmountDeposit);
+		await DAIVaultHandler.createVault();
+		await DAIVaultHandler.addCollateral(DAICollateralAmountDeposit);
+		// Mint same amount of Tcap minted in Btc Vault
+		await DAIVaultHandler.mint(tcapAmount);
+		const oldDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(oldDAIVaultRatio).to.be.above(150);
+		expect(oldBTCVaultRatio.toNumber()).to.be.closeTo(oldDAIVaultRatio.toNumber(), 1);
+
+		// Simulate Oracle price change
+		// reduce price by 30%, mul(70).div(100) -> 70%
+		const newWBTCOracleValue = wBTCOracleValue.mul(70).div(100);
+		aggregatorInterfaceWBTC.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			newWBTCOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await wBTCOracle.getLatestAnswer()).to.be.eq(newWBTCOracleValue);
+
+		const newDAIOracleValue = DAIOracleValue.mul(70).div(100);
+		aggregatorInterfaceDAI.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			newDAIOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await DAIOracle.getLatestAnswer()).to.be.eq(newDAIOracleValue);
+		const newBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(newBTCVaultRatio).to.be.below(150);
+		const newDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(newDAIVaultRatio).to.be.below(150);
+		expect(newBTCVaultRatio.toNumber()).to.be.eq(newDAIVaultRatio.toNumber());
+
+		const BTCTcapLiquidationAmount = await wBTCVaultHandler.requiredLiquidationTCAP(1);
+		const DAITcapLiquidationAmount = await DAIVaultHandler.requiredLiquidationTCAP(1);
+
+		expect(
+			BTCTcapLiquidationAmount.toHexString() / 10 ** 18
+		).to.be.closeTo(
+			DAITcapLiquidationAmount.toHexString() / 10 ** 18,
+			0.01
+		);
+
+	});
+
+	it("...should have same liquidationReward when vault ratio goes down", async () => {
+		const USDAmountCollateralToDeposit = BigNumber.from(1000);
+		// equivalent in decimals places supported by WBTC
+		const btcCollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			10 ** 8 // wBTC supports 8 decimals
+		).div(
+			wBTCOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		const DAICollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			`${10 ** 18}` // DAI supports 18 decimals
+		).div(
+			DAIOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		// TCAP amount to be minted by both vaults
+		// A weird number is chosen in order to check the precision of the math.
+		// approx 2.4 TCAP
+		let tcapAmount = BigNumber.from("2418604651162790553");
+
+		await wBTCVaultHandler.createVault();
+		await wBTC.approve(wBTCVaultHandler.address, btcCollateralAmountDeposit);
+		await wBTCVaultHandler.addCollateral(btcCollateralAmountDeposit);
+		// Mint a small amount of TCAP
+		await wBTCVaultHandler.mint(tcapAmount);
+		const oldBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(oldBTCVaultRatio).to.be.above(150);
+
+		await DAI.approve(DAIVaultHandler.address, DAICollateralAmountDeposit);
+		await DAIVaultHandler.createVault();
+		await DAIVaultHandler.addCollateral(DAICollateralAmountDeposit);
+		// Mint same amount of Tcap minted in Btc Vault
+		await DAIVaultHandler.mint(tcapAmount);
+		const oldDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(oldDAIVaultRatio).to.be.above(150);
+		expect(oldBTCVaultRatio.toNumber()).to.be.closeTo(oldDAIVaultRatio.toNumber(), 1);
+
+		// Simulate Oracle price change
+		// reduce price by 30%, mul(70).div(100) -> 70%
+		const newWBTCOracleValue = wBTCOracleValue.mul(70).div(100);
+		aggregatorInterfaceWBTC.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			newWBTCOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await wBTCOracle.getLatestAnswer()).to.be.eq(newWBTCOracleValue);
+
+		const newDAIOracleValue = DAIOracleValue.mul(70).div(100);
+		aggregatorInterfaceDAI.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			newDAIOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await DAIOracle.getLatestAnswer()).to.be.eq(newDAIOracleValue);
+		const newBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(newBTCVaultRatio).to.be.below(150);
+		const newDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(newDAIVaultRatio).to.be.below(150);
+		expect(newBTCVaultRatio.toNumber()).to.be.eq(newDAIVaultRatio.toNumber());
+
+		const BTCLiquidationReward = await wBTCVaultHandler.liquidationReward(1);
+		const DAILiquidationReward = await DAIVaultHandler.liquidationReward(1);
+		const BTCRewardInUSD = newWBTCOracleValue.mul(
+			BTCLiquidationReward
+		).div(BigNumber.from(`${10 ** 8}`)).div(BigNumber.from(`${10 ** 8}`))
+		const DAIRewardInUSD = newDAIOracleValue.mul(
+			DAILiquidationReward
+		).div(BigNumber.from(`${10 ** 8}`)).div(BigNumber.from(`${10 ** 18}`))
+		expect(BTCRewardInUSD.toNumber()).to.be.closeTo(DAIRewardInUSD.toNumber(), 2);
+	});
+
+	it("...should have same vault ratio after liquidating vault", async () => {
+		const USDAmountCollateralToDeposit = BigNumber.from(1000);
+		// equivalent in decimals places supported by WBTC
+		const btcCollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			10 ** 8 // wBTC supports 8 decimals
+		).div(
+			wBTCOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		const DAICollateralAmountDeposit = USDAmountCollateralToDeposit.mul(
+			`${10 ** 18}` // DAI supports 18 decimals
+		).div(
+			DAIOracleValue.div(10 ** 8) // oracle has 8 decimals
+		)
+		// TCAP amount to be minted by both vaults
+		// A weird number is chosen in order to check the precision of the math.
+		// approx 2.4 TCAP
+		let tcapAmount = BigNumber.from("2418604651162790553");
+
+		await wBTCVaultHandler.createVault();
+		await wBTC.approve(wBTCVaultHandler.address, btcCollateralAmountDeposit);
+		await wBTCVaultHandler.addCollateral(btcCollateralAmountDeposit);
+		// Mint a small amount of TCAP
+		await wBTCVaultHandler.mint(tcapAmount);
+		const oldBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(oldBTCVaultRatio).to.be.above(150);
+
+		await DAI.approve(DAIVaultHandler.address, DAICollateralAmountDeposit);
+		await DAIVaultHandler.createVault();
+		await DAIVaultHandler.addCollateral(DAICollateralAmountDeposit);
+		// Mint same amount of Tcap minted in Btc Vault
+		await DAIVaultHandler.mint(tcapAmount);
+		const oldDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(oldDAIVaultRatio).to.be.above(150);
+		expect(oldBTCVaultRatio.toNumber()).to.be.closeTo(oldDAIVaultRatio.toNumber(), 1);
+
+		// Simulate Oracle price change
+		// reduce price by 30%, mul(70).div(100) -> 70%
+		const newWBTCOracleValue = wBTCOracleValue.mul(70).div(100);
+		aggregatorInterfaceWBTC.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			newWBTCOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await wBTCOracle.getLatestAnswer()).to.be.eq(newWBTCOracleValue);
+
+		const newDAIOracleValue = DAIOracleValue.mul(70).div(100);
+		aggregatorInterfaceDAI.latestRoundData.returns([
+			BigNumber.from("55340232221128679816"),
+			newDAIOracleValue,
+			1616543796,
+			1616543819,
+			BigNumber.from("55340232221128679816")
+		]);
+		expect(await DAIOracle.getLatestAnswer()).to.be.eq(newDAIOracleValue);
+		const newBTCVaultRatio = await wBTCVaultHandler.getVaultRatio(1);
+		expect(newBTCVaultRatio).to.be.below(150);
+		const newDAIVaultRatio = await DAIVaultHandler.getVaultRatio(1);
+		expect(newDAIVaultRatio).to.be.below(150);
+		expect(newBTCVaultRatio.toNumber()).to.be.eq(newDAIVaultRatio.toNumber());
+
+		const BTCTcapLiquidationAmount = await wBTCVaultHandler.requiredLiquidationTCAP(1);
+		const DAITcapLiquidationAmount = await DAIVaultHandler.requiredLiquidationTCAP(1);
+
+		expect(
+			BTCTcapLiquidationAmount.toHexString() / 10 ** 18
+		).to.be.closeTo(
+			DAITcapLiquidationAmount.toHexString() / 10 ** 18,
+			0.01
+		);
+
+		const BTCBurnFee = await wBTCVaultHandler.getFee(BTCTcapLiquidationAmount);
+		const DAIBurnFee = await DAIVaultHandler.getFee(DAITcapLiquidationAmount);
+		await wBTCVaultHandler.liquidateVault(1, BTCTcapLiquidationAmount, {value: BTCBurnFee});
+		await DAIVaultHandler.liquidateVault(1, DAITcapLiquidationAmount, {value: DAIBurnFee});
+		expect(
+			await wBTCVaultHandler.getVaultRatio(1)
+		).to.be.eq(
+			await DAIVaultHandler.getVaultRatio(1)
+		);
+
+	});
+
+});

--- a/test/ERCVaultHandler.test.js
+++ b/test/ERCVaultHandler.test.js
@@ -61,8 +61,10 @@ describe("ERC20 Vault", async function () {
 		tcapOracleInstance = await oracle.deploy(aggregatorTCAPInstance.address, accounts[0]);
 		await priceOracleInstance.deployed();
 
-		const wbtc = await ethers.getContractFactory("WBTC");
-		ercTokenInstance = await wbtc.deploy();
+		// Tests here are correct only for ERC20 tokens with 18 decimal places
+		// Using DAI as it has 18 decimals
+		const DAI = await ethers.getContractFactory("DAI");
+		ercTokenInstance = await DAI.deploy();
 
 		// Initialize Vault
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,18 @@
     "@truffle/contract" "^4.2.29"
     ethers "^4.0.45"
 
+"@defi-wonderland/smock@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@defi-wonderland/smock/-/smock-2.0.7.tgz#59d5fc93e175ad120c5dcdd8294e07525606c855"
+  integrity sha512-RVpODLKZ/Cr0C1bCbhJ2aXbAr2Ll/K2WO7hDL96tqhMzCsA7ToWdDIgiNpV5Vtqqvpftu5ddO7v3TAurQNSU0w==
+  dependencies:
+    "@nomiclabs/ethereumjs-vm" "^4.2.2"
+    diff "^5.0.0"
+    lodash.isequal "^4.5.0"
+    lodash.isequalwith "^4.4.0"
+    rxjs "^7.2.0"
+    semver "^7.3.5"
+
 "@ensdomains/ens@^0.4.4":
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/@ensdomains/ens/-/ens-0.4.5.tgz#e0aebc005afdc066447c6e22feb4eda89a5edbfc"
@@ -1046,6 +1058,27 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
+
+"@nomiclabs/ethereumjs-vm@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.2.2.tgz#2f8817113ca0fb6c44c1b870d0a809f0e026a6cc"
+  integrity sha512-8WmX94mMcJaZ7/m7yBbyuS6B+wuOul+eF+RY9fBpGhNaUpyMR/vFIcDojqcWQ4Yafe1tMKY5LDu2yfT4NZgV4Q==
+  dependencies:
+    async "^2.1.2"
+    async-eventemitter "^0.2.2"
+    core-js-pure "^3.0.1"
+    ethereumjs-account "^3.0.0"
+    ethereumjs-block "^2.2.2"
+    ethereumjs-blockchain "^4.0.3"
+    ethereumjs-common "^1.5.0"
+    ethereumjs-tx "^2.1.2"
+    ethereumjs-util "^6.2.0"
+    fake-merkle-patricia-tree "^1.0.1"
+    functional-red-black-tree "^1.0.1"
+    merkle-patricia-tree "3.0.0"
+    rustbn.js "~0.2.0"
+    safe-buffer "^5.1.1"
+    util.promisify "^1.0.0"
 
 "@nomiclabs/hardhat-ethers@^2.0.1":
   version "2.0.1"
@@ -3611,6 +3644,11 @@ diff@4.0.2, diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -6542,6 +6580,16 @@ lodash.escaperegexp@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.isequalwith@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
+  integrity sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -8318,6 +8366,13 @@ rustbn.js@~0.2.0:
   resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
+rxjs@^7.2.0:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.2.tgz#11e4a3a1dfad85dbf7fb6e33cbba17668497490b"
+  integrity sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -8436,6 +8491,13 @@ semver@^7.3.2, semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -9328,6 +9390,11 @@ tslib@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsort@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
### What was wrong?
The protocol calculations didn't work with ERC20 tokens with less than 18 decimals.

### How was it fixed?
Introduced a new variable called `collateralDecimalsAdjustmentFactor` which is equal to 
`collateralDecimalsAdjustmentFactor = 10 ** (18 - DecimalsOfERC20Token)`
This variable is multiplied or divided accordingly to adjust for the extra decimal places.

### How was it tested?
1. I used two vaults, one with 18 decimals and another with less than 18.
2. Calculations for tokens with 18 decimals are assumed to be correct.
3. Different vault parameters are then compared for an equal amount of collateral deposited in USD.
4. By checking that the calculations for both tokens are equivalent in USD, from `3` we can conclude that the calculations for tokens with less than 18 decimals are correct.
5. Introduced [smock](https://smock.readthedocs.io/en/latest/) as a dependency for mocking oracle prices. 