### PR TITLE
added support for decimals in burn fee

### DIFF
--- a/contracts/IVaultHandler.sol
+++ b/contracts/IVaultHandler.sol
@@ -102,8 +102,8 @@ IERC165
 	/// @notice Minimum value that the ratio can be set to
 	uint256 public constant MIN_RATIO = 100;
 
-	/// @notice Maximum value that the burn fee can be set to
-	uint256 public constant MAX_FEE = 10;
+	/// @notice Maximum value that the burn fee can be set to, the fee have two decimals so it's multiplied by 100
+	uint256 public constant MAX_FEE = 1000; /// max fee 10%
 
 	/**
 	 * @dev the computed interface ID according to ERC-165. The interface ID is a XOR of interface method selectors.
@@ -786,16 +786,17 @@ IERC165
    * @param _amount to burn
    * @return fee
    * @dev The returned value is returned in wei
-   * @dev f = (((P * A * b)/ 100))/ EP
+   * @dev f = (((P * A * b)/ 10000))/ EP
    * f = Burn Fee Value in wei
    * P = TCAP Token Price
    * A = TCAP Amount to Burn
    * b = Burn Fee %
    * EP = ETH Price
+   * 10000 = the value is 100 multiplied by 100 to support two decimals on the burn fee
    */
 	function getFee(uint256 _amount) public view virtual returns (uint256 fee) {
 		uint256 ethPrice = getOraclePrice(ETHPriceOracle);
-		fee = (TCAPPrice().mul(_amount).mul(burnFee)).div(100).div(ethPrice);
+		fee = (TCAPPrice().mul(_amount).mul(burnFee)).div(10000).div(ethPrice);
 	}
 
 	/**

--- a/contracts/IVaultHandler.sol
+++ b/contracts/IVaultHandler.sol
@@ -102,7 +102,7 @@ IERC165
 	/// @notice Minimum value that the ratio can be set to
 	uint256 public constant MIN_RATIO = 100;
 
-	/// @notice Maximum value that the burn fee can be set to, the fee have two decimals so it's multiplied by 100
+	/// @notice Maximum value that the burn fee can be set to, the fee has two decimals, so it's multiplied by 100
 	uint256 public constant MAX_FEE = 1000; /// max fee 10%
 
 	/**

--- a/test/ERCVaultHandler.test.js
+++ b/test/ERCVaultHandler.test.js
@@ -330,7 +330,7 @@ describe("ERC20 Vault", async function () {
 
 	it("...should calculate the burn fee", async () => {
 		let amount = ethersProvider.utils.parseEther("10");
-		let divisor = 100;
+		let divisor = 10000;
 		let tcapPrice = await ercTokenHandler.TCAPPrice();
 		let ethPrice = (await priceOracleInstance.getLatestAnswer()).mul(10000000000);
 		let result = tcapPrice.mul(amount).div(divisor).div(ethPrice);

--- a/test/ETHVaultHandler.test.js
+++ b/test/ETHVaultHandler.test.js
@@ -365,7 +365,7 @@ describe("ETH Vault", async function () {
 
 	it("...should calculate the burn fee", async () => {
 		let amount = ethers.utils.parseEther("10");
-		let divisor = 100;
+		let divisor = 10000;
 		let tcapPrice = await ethTokenHandler.TCAPPrice();
 		let ethPrice = (await priceOracleInstance.getLatestAnswer()).mul(10000000000);
 		let result = tcapPrice.mul(amount).div(divisor).div(ethPrice);

--- a/test/MATICVaultHandler.test.js
+++ b/test/MATICVaultHandler.test.js
@@ -360,7 +360,7 @@ describe("MATIC Vault", async function () {
 
 	it("...should calculate the burn fee", async () => {
 		let amount = ethers.utils.parseEther("10");
-		let divisor = 100;
+		let divisor = 10000;
 		let tcapPrice = await maticTokenHandler.TCAPPrice();
 		let ethPrice = (await priceOracleInstance.getLatestAnswer()).mul(10000000000);
 		let result = tcapPrice.mul(amount).div(divisor).div(ethPrice);

--- a/test/Orchestrator.test.js
+++ b/test/Orchestrator.test.js
@@ -172,7 +172,7 @@ describe("Orchestrator Contract", async function () {
 		await orchestratorInstance.setBurnFee(ethVaultInstance.address, burnFee);
 		expect(burnFee).to.eq(await ethVaultInstance.burnFee());
 
-		await expect(orchestratorInstance.setBurnFee(ethVaultInstance.address, 100)).to.be.revertedWith(
+		await expect(orchestratorInstance.setBurnFee(ethVaultInstance.address, 1001)).to.be.revertedWith(
 			"VaultHandler::setBurnFee: burn fee higher than MAX_FEE"
 		);
 	});


### PR DESCRIPTION
What changed:
- Updated MAX_FEE value to handle decimals. (max value is 10%)
- Updated getFee() function to calculate the fee with the new decimals for burn fee
- Added Foundry tests to test the change of burn fee with fuzzing 
- Updated formula calculation on hardhat tests.