### PR TITLE
Implemented fixes suggested by Quantstamp

### DIFF
--- a/contracts/arbitrum/L1MessageRelayer.sol
+++ b/contracts/arbitrum/L1MessageRelayer.sol
@@ -39,21 +39,6 @@ contract L1MessageRelayer is Ownable {
   }
 
   /**
-   * @dev Update the address of the L2MessageExecutorProxy contract.
-   * @param _l2MessageExecutorProxy the address of L2 contract used to relay L1 messages.
-   **/
-  function updateL2MessageExecutorProxy(address _l2MessageExecutorProxy)
-    external
-    onlyTimeLock
-  {
-    require(
-      _l2MessageExecutorProxy != address(0),
-      "L1MessageRelayer::updateL2MessageExecutorProxy _l2MessageExecutorProxy is the zero address"
-    );
-    l2MessageExecutorProxy = _l2MessageExecutorProxy;
-  }
-
-  /**
    * @notice sends message received from timeLock to L2MessageExecutorProxy.
    * @param target address of the target contract on arbitrum.
    * @param payLoad message calldata that will be executed by l2MessageExecutorProxy.

--- a/contracts/arbitrum/L1MessageRelayer.sol
+++ b/contracts/arbitrum/L1MessageRelayer.sol
@@ -10,9 +10,6 @@ contract L1MessageRelayer is Ownable {
   /// @notice Address of the governance TimeLock contract.
   address public timeLock;
 
-  /// @notice Address of the L2MessageExecutorProxy contract on arbitrum.
-  address public l2MessageExecutorProxy;
-
   /// @notice Address of arbitrum's L1 inbox contract.
   IInbox public inbox;
 
@@ -35,19 +32,7 @@ contract L1MessageRelayer is Ownable {
     inbox = IInbox(_inbox);
   }
 
-  /**
-   * @dev Initialises the address of the l2MessageExecutorProxy contract.
-   * @param _l2MessageExecutorProxy the address of L2 contract used to relay L1 messages.
-   **/
-  function setL2MessageExecutorProxy(address _l2MessageExecutorProxy) external onlyOwner {
-    require(
-      l2MessageExecutorProxy == address(0x0),
-      "L1MessageRelayer::setL2MessageExecutorProxy: l2MessageExecutorProxy is already set"
-    );
-    l2MessageExecutorProxy = _l2MessageExecutorProxy;
-  }
-
-	/// @notice renounceOwnership has been disabled so that the contract is never left without a onwer
+  /// @notice renounceOwnership has been disabled so that the contract is never left without a onwer
   /// @inheritdoc Ownable
   function renounceOwnership() public override onlyOwner {
     revert("function disabled");
@@ -70,29 +55,30 @@ contract L1MessageRelayer is Ownable {
 
   /**
    * @notice sends message received from timeLock to L2MessageExecutorProxy.
-   * @param payLoad message received from L1 that needs to be executed.
+   * @param target address of the target contract on arbitrum.
+   * @param payLoad message calldata that will be executed by l2MessageExecutorProxy.
+   * @param maxSubmissionCost same as maxSubmissionCost parameter of inbox.createRetryableTicket
+   * @param maxGas same as maxGas parameter of inbox.createRetryableTicket
+   * @param gasPriceBid same as gasPriceBid parameter of inbox.createRetryableTicket
    **/
   function relayMessage(
-    bytes calldata payLoad,
+    address target,
+    bytes memory payLoad,
     uint256 maxSubmissionCost,
     uint256 maxGas,
     uint256 gasPriceBid
   ) external payable onlyTimeLock returns (uint256) {
     require(maxGas != 1, "maxGas can't be 1");
     require(gasPriceBid != 1, "gasPriceBid can't be 1");
-    bytes memory data = abi.encodeWithSelector(
-      L2MessageExecutor.executeMessage.selector,
-      payLoad
-    );
     uint256 ticketID = inbox.createRetryableTicket{value: msg.value}(
-      l2MessageExecutorProxy,
+      target,
       0,
       maxSubmissionCost,
       msg.sender,
       msg.sender,
       maxGas,
       gasPriceBid,
-      data
+      payLoad
     );
     emit RetryableTicketCreated(ticketID);
     return ticketID;

--- a/contracts/arbitrum/L2AdminProxy.sol
+++ b/contracts/arbitrum/L2AdminProxy.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/ProxyAdmin.sol";
+import {AddressAliasHelper} from "./AddressAliasHelper.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract L2AdminProxy is ProxyAdmin {
+  address private _owner;
+
+  /**
+   * @dev Initializes the contract setting the deployer as the initial owner.
+   */
+  constructor(address owner) {
+    _owner = owner;
+    emit OwnershipTransferred(address(0), owner);
+  }
+
+  /// @dev override admin so so that it returns the address offset by arbitrum's sequencer
+  /// @inheritdoc Ownable
+  function owner() public view override returns (address) {
+    return AddressAliasHelper.applyL1ToL2Alias(_owner);
+  }
+
+  /// @notice renounceOwnership has been disabled so that the contract is never left without a onwer
+  /// @inheritdoc Ownable
+  function renounceOwnership() public override onlyOwner {
+    revert("function disabled");
+  }
+
+  /// @inheritdoc Ownable
+  function transferOwnership(address newOwner) public override onlyOwner {
+    require(newOwner != address(0), "Ownable: new owner is the zero address");
+    emit OwnershipTransferred(_owner, newOwner);
+    _owner = newOwner;
+  }
+}

--- a/contracts/arbitrum/L2MessageExecutor.sol
+++ b/contracts/arbitrum/L2MessageExecutor.sol
@@ -27,17 +27,6 @@ contract L2MessageExecutor is ReentrancyGuard {
   }
 
   /**
-   * @notice Throws if called by any account other than this contract.
-   **/
-  modifier onlyThis() {
-    require(
-      msg.sender == address(this),
-      "L2MessageExecutor: Unauthorized message sender"
-    );
-    _;
-  }
-
-  /**
    * @notice executes message received from L1.
    * @param payLoad message received from L1 that needs to be executed.
    **/

--- a/contracts/arbitrum/L2MessageExecutor.sol
+++ b/contracts/arbitrum/L2MessageExecutor.sol
@@ -16,6 +16,12 @@ contract L2MessageExecutor is ReentrancyGuard {
   /// @dev flag to make sure that the initialize function is only called once
   bool private isInitialized = false;
 
+  constructor() {
+		// Disable initialization for external users.
+		// Only proxies should be able to initialize this contract.
+    isInitialized = true;
+  }
+
   function initialize(address _l1MessageRelayer) external {
     require(!isInitialized, "Contract is already initialized!");
     isInitialized = true;

--- a/contracts/arbitrum/L2MessageExecutorProxy.sol
+++ b/contracts/arbitrum/L2MessageExecutorProxy.sol
@@ -2,11 +2,12 @@
 pragma solidity 0.7.5;
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/TransparentUpgradeableProxy.sol";
+import {AddressAliasHelper} from "./AddressAliasHelper.sol";
 
 contract L2MessageExecutorProxy is TransparentUpgradeableProxy {
   constructor(
     address l2MessageExecutor,
-    address timelock,
+    address l2AdminProxy,
     bytes memory callData
-  ) TransparentUpgradeableProxy(l2MessageExecutor, timelock, callData) {}
+  ) TransparentUpgradeableProxy(l2MessageExecutor, l2AdminProxy, callData) {}
 }

--- a/test/arbitrum/ArbitrumMessages.t.sol
+++ b/test/arbitrum/ArbitrumMessages.t.sol
@@ -78,19 +78,6 @@ contract ArbitrumMessages is Test {
 		);
   }
 
-  function testRevertOnUpdateExecutor() public {
-    vm.expectRevert("L1MessageRelayer::onlyTimeLock: Unauthorized message sender");
-    l1MessageRelayer.updateL2MessageExecutorProxy(address(l2MessageExecutor));
-  }
-
-  function testUpdateL2MessageExecutor() public {
-    vm.startPrank(user);
-    assertEq(l1MessageRelayer.l2MessageExecutorProxy(), address(l2MessageExecutor));
-    l1MessageRelayer.updateL2MessageExecutorProxy(user);
-    assertEq(l1MessageRelayer.l2MessageExecutorProxy(), user);
-    vm.stopPrank();
-  }
-
 	function testRevertForZeroTimelockAddress() public {
 		vm.expectRevert(
       "_timeLock can't the zero address"

--- a/test/arbitrum/ArbitrumTreasury.sol
+++ b/test/arbitrum/ArbitrumTreasury.sol
@@ -1,48 +1,58 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.7.5;
 
+import "@openzeppelin/contracts/utils/Address.sol";
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 import "../../contracts/arbitrum/L2MessageExecutor.sol";
 import "../../contracts/arbitrum/ArbitrumTreasury.sol";
 import "../../contracts/arbitrum/AddressAliasHelper.sol";
+import "../../contracts/arbitrum/L2MessageExecutorProxy.sol";
 
 
 contract ArbitrumTreasuryTest is Test {
-  address user = address(0x1);
+  address user = address(0x51);
+	address user2 = address(0x52);
 
   L2MessageExecutor l2MessageExecutor;
 	ArbitrumTreasury treasury;
+	L2MessageExecutorProxy proxy;
 
   function setUp() public {
     vm.startPrank(address(user));
     l2MessageExecutor = new L2MessageExecutor();
-		l2MessageExecutor.initialize(user);
-    treasury = new ArbitrumTreasury(address(l2MessageExecutor));
+		proxy = new L2MessageExecutorProxy(
+			address(l2MessageExecutor),
+			user,
+			abi.encodeWithSelector(
+				l2MessageExecutor.initialize.selector,
+				address(user)
+			)
+		);
+    treasury = new ArbitrumTreasury(address(proxy));
     vm.stopPrank();
   }
 
   function testUpdateOwner() public {
-    assertEq(treasury.owner(), address(l2MessageExecutor));
+		assertEq(treasury.owner(), address(proxy));
 		vm.startPrank(AddressAliasHelper.applyL1ToL2Alias(address(user)));
-		L2MessageExecutor newL2MessageExecutor = new L2MessageExecutor();
-		newL2MessageExecutor.initialize(user);
+		address newOwner = user2;
 		bytes memory callData = abi.encodeWithSelector(
       treasury.transferOwnership.selector,
-      address(newL2MessageExecutor)
+      newOwner
     );
     bytes memory payLoad = abi.encode(address(treasury), callData);
-		l2MessageExecutor.executeMessage(payLoad);
-		assertEq(treasury.owner(), address(newL2MessageExecutor));
+		Address.functionCall(
+      address(proxy),
+      abi.encodeWithSelector(l2MessageExecutor.executeMessage.selector, payLoad)
+    );
+		assertEq(treasury.owner(), newOwner);
 		vm.stopPrank();
   }
 
 	function testRenounceOwnershipShouldRevert() public {
 		vm.startPrank(AddressAliasHelper.applyL1ToL2Alias(address(user)));
-
-		L2MessageExecutor newL2MessageExecutor = new L2MessageExecutor();
-		newL2MessageExecutor.initialize(user);
 		bytes memory callData = abi.encodeWithSelector(
       treasury.renounceOwnership.selector
     );
@@ -50,7 +60,10 @@ contract ArbitrumTreasuryTest is Test {
 		vm.expectRevert(
       "L2MessageExecutor::executeMessage: Message execution reverted."
     );
-		l2MessageExecutor.executeMessage(payLoad);
+		Address.functionCall(
+      address(proxy),
+      abi.encodeWithSelector(l2MessageExecutor.executeMessage.selector, payLoad)
+    );
 		vm.stopPrank();
 	}
 

--- a/test/arbitrum/L2AdminProxy.t.sol
+++ b/test/arbitrum/L2AdminProxy.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import "../../contracts/arbitrum/L2AdminProxy.sol";
+import "../../contracts/arbitrum/AddressAliasHelper.sol";
+
+contract L2AdminProxyTest is Test {
+  L2AdminProxy _l2AdminProxy;
+
+  address owner = address(0x51);
+
+  function setUp() external {
+    _l2AdminProxy = new L2AdminProxy(owner);
+  }
+
+  function testOwnerSetCorrectly() external {
+    assertEq(_l2AdminProxy.owner(), AddressAliasHelper.applyL1ToL2Alias(owner));
+  }
+
+  function testTransferOwnerShip() external {
+    address newOwner = address(0x52);
+    vm.prank(AddressAliasHelper.applyL1ToL2Alias(owner));
+    _l2AdminProxy.transferOwnership(newOwner);
+    assertEq(
+      _l2AdminProxy.owner(),
+      AddressAliasHelper.applyL1ToL2Alias(newOwner)
+    );
+  }
+
+  function testRevertWhenNonOwnerTransfersOwnership() external {
+    vm.expectRevert("Ownable: caller is not the owner");
+    _l2AdminProxy.transferOwnership(address(0x52));
+  }
+
+  function testRevertonRenounceOwnership() external {
+    vm.startPrank(AddressAliasHelper.applyL1ToL2Alias(owner));
+    vm.expectRevert("function disabled");
+    _l2AdminProxy.renounceOwnership();
+  }
+}

--- a/test/arbitrum/L2MessageExecutorProxy.t.sol
+++ b/test/arbitrum/L2MessageExecutorProxy.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+import "forge-std/console.sol";
+import "forge-std/Test.sol";
+
+import "../../contracts/arbitrum/AddressAliasHelper.sol";
+import "../../contracts/arbitrum/L2MessageExecutorProxy.sol";
+import "../../contracts/mocks/Greeter.sol";
+
+// This contract is used to test upgrade functionality of L2MessageExecutorProxy
+contract NewGreeter is Greeter {
+  // The constructor is not needed here as it won't be executed by the proxy.
+  // But since the greeter code is being re-used, the constructor is needed.
+  constructor(string memory _greeting) Greeter(_greeting) {}
+
+  function setGreeting(string memory _greeting) public override {
+    greeting = string(abi.encodePacked("NewGreeter: ", _greeting));
+  }
+}
+
+contract L2MessageExecutorProxyTest is Test {
+  L2MessageExecutorProxy _l2MessageExecutorProxy;
+  Greeter _greeter;
+
+  address timelock = address(0x51);
+  address _l2adminProxy = address(0x52);
+
+  function setUp() external {
+    _greeter = new Greeter("");
+    _l2MessageExecutorProxy = new L2MessageExecutorProxy(
+      address(_greeter),
+      _l2adminProxy,
+      abi.encodeWithSelector(_greeter.setGreeting.selector, "First Message")
+    );
+  }
+
+  function testAdminSetCorrectly() external {
+    vm.startPrank(_l2adminProxy);
+    assertEq(_l2MessageExecutorProxy.admin(), _l2adminProxy);
+    vm.stopPrank();
+  }
+
+  function testAdminCannotCallFallback() external {
+    // prank admin address
+    vm.startPrank(_l2adminProxy);
+    vm.expectRevert(
+      "TransparentUpgradeableProxy: admin cannot fallback to proxy target"
+    );
+    bytes memory message = Address.functionCall(
+      address(_l2MessageExecutorProxy),
+      abi.encodeWithSelector(_greeter.greet.selector)
+    );
+  }
+
+  function testNonAdminAddressCanCallFallback() external {
+    bytes memory message = Address.functionCall(
+      address(_l2MessageExecutorProxy),
+      abi.encodeWithSelector(_greeter.greet.selector)
+    );
+    assertEq(abi.decode(message, (string)), "First Message");
+    Address.functionCall(
+      address(_l2MessageExecutorProxy),
+      abi.encodeWithSelector(_greeter.setGreeting.selector, "Second Message")
+    );
+    message = Address.functionCall(
+      address(_l2MessageExecutorProxy),
+      abi.encodeWithSelector(_greeter.greet.selector)
+    );
+    assertEq(abi.decode(message, (string)), "Second Message");
+  }
+
+  function testUpgradeImplementation() external {
+    NewGreeter _newGreeter = new NewGreeter("");
+    vm.startPrank(_l2adminProxy);
+    _l2MessageExecutorProxy.upgradeToAndCall(
+      address(_newGreeter),
+      abi.encodeWithSelector(_newGreeter.setGreeting.selector, "First Message")
+    );
+    vm.stopPrank();
+    bytes memory message = Address.functionCall(
+      address(_l2MessageExecutorProxy),
+      abi.encodeWithSelector(_newGreeter.greet.selector)
+    );
+    assertEq(abi.decode(message, (string)), "NewGreeter: First Message");
+  }
+
+  function testUpgradeFailsWhenNotAdmin() external {
+    NewGreeter _newGreeter = new NewGreeter("");
+    vm.expectRevert();
+    _l2MessageExecutorProxy.upgradeToAndCall(
+      address(_newGreeter),
+      abi.encodeWithSelector(_newGreeter.setGreeting.selector, "First Message")
+    );
+  }
+}


### PR DESCRIPTION
todo
- [x] Write integration tests
- [x]  Implement QSP-2
- [x]  Decide whether QSP-5 needs to be fixed

----
### Code Changes
1. Changes related to [QSP-1](https://github.com/cryptexfinance/contracts/pull/141/commits/fddf12b003d90111f587bdd19472d2a782802277)
a. Added a new contract called `L2AdminProxy` that will be the owner of `L2MessageExecutorProxy `.
As part of this change, I had to override the `admin()` function, which led me to override `transferOwnership` and the `constructor`. 
b. changed parameter timelock to l2AdminProxy in the constructor of `L2MessageExecutorProxy`.
c. `L1MessageRelayer.relayMessage` now takes a `target` address as a parameter instead of hardcoding to the target address to `L2MessageExecutorProxy`. This was done so that messages could also be relayed to the `L2AdminProxy` via the Arbitrum sequencer. 
d. Added unit and integration tests to ensure that the upgrade functionality works as expected.

2. [QSP-3](https://github.com/cryptexfinance/contracts/pull/141/commits/481d902a74485a3c7fc1c12a7825445f1a475881)
removed unused `onlyThis` modifier

3. [QSP-4](https://github.com/cryptexfinance/contracts/pull/141/commits/5635e37767784330d03bbace8ed629c311887f63)
removed `updateL2MessageExecutorProxy` from `L1MessageRelayer` so that the proxy address cannot be upgraded. 

4. [QSP-2](https://github.com/cryptexfinance/contracts/pull/141/commits/9e15067e43101e94b80dfb312f3424590bea3036)
Disabled initialization function of implementation contract for external users

5. QSP-5
We acknowledge it but we won't fix it.